### PR TITLE
Tweaks and fixes (details in description)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,8 @@ jar {
 }
 
 dependencies {
-    compile files(
-        'Baubles-deobf.jar'
-    )
+    compile "baubles:Baubles:1.12:1.5.2"
+    compile "autoreglib:AutoRegLib:1.3:26"
 }
 
 processResources {
@@ -67,6 +66,12 @@ processResources {
     // copy everything else, thats not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info', '**/psd/**'
+    }
+}
+
+repositories {
+	maven {
+        url = "https://minecraft.curseforge.com/api/maven/"
     }
 }
 

--- a/build.properties
+++ b/build.properties
@@ -1,10 +1,10 @@
 #
-#Wed Oct 18 11:59:44 BST 2017
+#Wed Mar 13 22:27:25 GMT+01:00 2019
 version=r1.0
-mc_mappings=snapshot_20170624
+mc_mappings=stable_39
 dir_output=../Build Output/PotionFingers/
+mc_version=1.12.2
+forge_version=14.23.5.2815
 dir_repo=./
-forge_version=14.22.0.2467
-mc_version=1.12.1
 build_number=3
 mod_name=PotionFingers

--- a/src/main/java/vazkii/potionfingers/ItemRing.java
+++ b/src/main/java/vazkii/potionfingers/ItemRing.java
@@ -93,7 +93,8 @@ public class ItemRing extends ItemMod implements IBauble, IItemColorProvider {
 	@SideOnly(Side.CLIENT)
 	public IItemColor getItemColor() {
 		return new IItemColor() {
-			public int getColorFromItemstack(ItemStack stack, int i) {
+			@Override
+			public int colorMultiplier(ItemStack stack, int i) {
 				if(i != 0) {
 					Potion p = getPotion(stack);
 					if(p != null)

--- a/src/main/java/vazkii/potionfingers/ItemRing.java
+++ b/src/main/java/vazkii/potionfingers/ItemRing.java
@@ -4,6 +4,7 @@ import baubles.api.BaubleType;
 import baubles.api.BaublesApi;
 import baubles.api.IBauble;
 import net.minecraft.client.renderer.color.IItemColor;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -13,7 +14,6 @@ import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.interf.IItemColorProvider;
@@ -66,7 +66,7 @@ public class ItemRing extends ItemMod implements IBauble, IItemColorProvider {
 		Potion p = getPotion(stack);
 		String potionName = "N/A";
 		if(p != null)
-			potionName = I18n.translateToLocal(p.getName());
+			potionName = I18n.format(p.getName());
 		
 		return String.format(name, potionName);
 	}

--- a/src/main/java/vazkii/potionfingers/ItemRing.java
+++ b/src/main/java/vazkii/potionfingers/ItemRing.java
@@ -128,8 +128,8 @@ public class ItemRing extends ItemMod implements IBauble, IItemColorProvider {
 				level++;
 			}
 		}
-		if (level > 2) {
-			level = 2;
+		if (level > 1) {
+			level = 1;
 		}
 		PotionEffect currentEffect = player.getActivePotionEffect(potion);
 		int currentLevel = currentEffect != null ? currentEffect.getAmplifier() : -1;

--- a/src/main/java/vazkii/potionfingers/ItemRing.java
+++ b/src/main/java/vazkii/potionfingers/ItemRing.java
@@ -3,12 +3,12 @@ package vazkii.potionfingers;
 import baubles.api.BaubleType;
 import baubles.api.BaublesApi;
 import baubles.api.IBauble;
+import baubles.api.cap.IBaublesItemHandler;
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
@@ -118,23 +118,21 @@ public class ItemRing extends ItemMod implements IBauble, IItemColorProvider {
 	public void updatePotionStatus(EntityLivingBase player, Potion potion) {
 		if(potion == null || !(player instanceof EntityPlayer))
 			return;
-		
-		IInventory inv = BaublesApi.getBaubles((EntityPlayer) player);
-		ItemStack ring1 = inv.getStackInSlot(1);
-		ItemStack ring2 = inv.getStackInSlot(2);
-		
-		Potion potion1 = getPotion(ring1);
-		Potion potion2 = getPotion(ring2);
-		
+		IBaublesItemHandler inv = BaublesApi.getBaublesHandler((EntityPlayer) player);
 		int level = -1;
-		if(potion1 == potion)
-			level++;
-		if(potion2 == potion)
-			level++;
-		
+		for (int slot:BaubleType.RING.getValidSlots()) {
+			ItemStack ring1 = inv.getStackInSlot(slot);
+			Potion potion1 = getPotion(ring1);
+			if (potion1 == potion) {
+				level++;
+			}
+		}
+		if (level > 2) {
+			level = 2;
+		}
 		PotionEffect currentEffect = player.getActivePotionEffect(potion);
 		int currentLevel = currentEffect != null ? currentEffect.getAmplifier() : -1;
-		if(currentLevel != level) {
+		if (currentLevel != level) {
 			player.removeActivePotionEffect(potion);
 			if(level != -1 && !player.world.isRemote)
 				player.addPotionEffect(new PotionEffect(potion, Integer.MAX_VALUE, level, true, false));

--- a/src/main/java/vazkii/potionfingers/PotionFingers.java
+++ b/src/main/java/vazkii/potionfingers/PotionFingers.java
@@ -6,7 +6,6 @@ import net.minecraft.init.MobEffects;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
-import net.minecraftforge.client.event.GuiScreenEvent.PotionShiftEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;


### PR DESCRIPTION
Removed "There are only two ring slots" assumption: enables compatibility with Bring Me The Rings.
Uses maven to fetch dependencies.
I also updated Minecraft, Forge and Mappings to more recent versions, and moved to non-deprecated versions for some methods/classes.
Tested to work with 1.12.2