### PR TITLE
Fix ring effects becoming permanent under some circumstances

### DIFF
--- a/src/main/java/vazkii/potionfingers/ItemRing.java
+++ b/src/main/java/vazkii/potionfingers/ItemRing.java
@@ -107,15 +107,16 @@ public class ItemRing extends ItemMod implements IBauble, IItemColorProvider {
 
 	@Override
 	public void onEquipped(ItemStack itemstack, EntityLivingBase player) {
-		updatePotionStatus(player, getPotion(itemstack));
+		updatePotionStatus(player, itemstack, false);
 	}
 	
 	@Override
 	public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {
-		updatePotionStatus(player, getPotion(itemstack));
+		updatePotionStatus(player, itemstack, true);
 	}
 	
-	public void updatePotionStatus(EntityLivingBase player, Potion potion) {
+	public void updatePotionStatus(EntityLivingBase player, ItemStack ring, boolean unequipping) {
+	    Potion potion = getPotion(ring);
 		if(potion == null || !(player instanceof EntityPlayer))
 			return;
 		
@@ -123,8 +124,8 @@ public class ItemRing extends ItemMod implements IBauble, IItemColorProvider {
 		ItemStack ring1 = inv.getStackInSlot(1);
 		ItemStack ring2 = inv.getStackInSlot(2);
 		
-		Potion potion1 = getPotion(ring1);
-		Potion potion2 = getPotion(ring2);
+		Potion potion1 = unequipping && ring == ring1 ? null : getPotion(ring1);
+		Potion potion2 = unequipping && ring == ring2 ? null : getPotion(ring2);
 		
 		int level = -1;
 		if(potion1 == potion)

--- a/src/main/java/vazkii/potionfingers/ItemRing.java
+++ b/src/main/java/vazkii/potionfingers/ItemRing.java
@@ -99,7 +99,7 @@ public class ItemRing extends ItemMod implements IBauble, IItemColorProvider {
 					if(p != null)
 						return p.getLiquidColor();
 				}
-				
+
 				return 0xFFFFFF;
 			}
 		};
@@ -135,8 +135,8 @@ public class ItemRing extends ItemMod implements IBauble, IItemColorProvider {
 		
 		PotionEffect currentEffect = player.getActivePotionEffect(potion);
 		int currentLevel = currentEffect != null ? currentEffect.getAmplifier() : -1;
-		if(currentLevel != level) {
-			player.removeActivePotionEffect(potion);
+		if (currentLevel != level) {
+			player.removePotionEffect(potion);
 			if(level != -1 && !player.world.isRemote)
 				player.addPotionEffect(new PotionEffect(potion, Integer.MAX_VALUE, level, true, false));
 		}


### PR DESCRIPTION
This PR fixes the issue outlined in #16 and #9, caused by rings still being counted in the potion update while swapping.
It also fixes a compatibility issue with PotionCore caused by calling the direct potion removal method instead of the one performing cleanups.